### PR TITLE
Add command palette for quick navigation

### DIFF
--- a/src/components/CommandPalette.astro
+++ b/src/components/CommandPalette.astro
@@ -1,0 +1,324 @@
+---
+import { getCollection } from "astro:content";
+import { ME } from "@/config";
+
+const resumeHref = `/${ME.contactInfo.resumeDoc}`;
+const emailHref = `mailto:${ME.contactInfo.email}?subject=${encodeURIComponent("Portfolio inquiry")}`;
+
+const latestProject = (await getCollection("projects")).sort(
+  (a, b) => b.data.startDate.getTime() - a.data.startDate.getTime()
+)[0];
+
+const latestPost = (await getCollection("posts")).sort(
+  (a, b) => b.data.publishDate.getTime() - a.data.publishDate.getTime()
+)[0];
+
+const actions = [
+  {
+    id: "home",
+    label: "Home",
+    description: "Go to the homepage",
+    href: "/",
+    kind: "route",
+    keywords: "profile landing about",
+  },
+  {
+    id: "projects",
+    label: "Projects",
+    description: "Browse all projects",
+    href: "/projects",
+    kind: "route",
+    keywords: "portfolio work build",
+  },
+  {
+    id: "blog",
+    label: "Blog",
+    description: "Read blog posts",
+    href: "/blog",
+    kind: "route",
+    keywords: "posts writing articles",
+  },
+  latestProject
+    ? {
+        id: "latest-project",
+        label: "Latest project",
+        description: latestProject.data.title,
+        href: `/projects/${latestProject.id}`,
+        kind: "route",
+        keywords: `newest recent ${latestProject.data.tags.join(" ")}`.trim(),
+      }
+    : null,
+  latestPost
+    ? {
+        id: "latest-post",
+        label: "Latest blog post",
+        description: latestPost.data.title,
+        href: `/blog/${latestPost.id}`,
+        kind: "route",
+        keywords: `newest recent ${latestPost.data.tags.join(" ")}`.trim(),
+      }
+    : null,
+  {
+    id: "email",
+    label: "Email me",
+    description: ME.contactInfo.email,
+    href: emailHref,
+    kind: "external",
+    keywords: "contact mail reach out",
+  },
+  {
+    id: "download-cv",
+    label: "Download CV",
+    description: "Open resume PDF",
+    href: resumeHref,
+    kind: "download",
+    keywords: "resume cv profile pdf",
+  },
+].filter(Boolean);
+---
+
+<div
+  data-command-palette
+  data-open="false"
+  class="fixed inset-0 z-50 hidden"
+  role="dialog"
+  aria-modal="true"
+  aria-hidden="true"
+  aria-labelledby="command-palette-title"
+>
+  <button
+    type="button"
+    data-command-backdrop
+    class="absolute inset-0 bg-slate-950/60"
+    tabindex="-1"
+    aria-label="Close command palette"
+  />
+
+  <div class="relative mx-auto mt-20 w-[min(92vw,620px)] rounded-sm border border-slate-200 bg-slate-50 shadow-sm dark:border-slate-800 dark:bg-slate-900">
+    <div class="border-b border-slate-200 p-3 dark:border-slate-800">
+      <div class="flex items-center justify-between gap-2">
+        <h2 id="command-palette-title" class="text-sm font-display font-bold text-slate-800 dark:text-slate-100">
+          Quick actions
+        </h2>
+        <span class="text-xs font-display text-slate-500 dark:text-slate-400">Esc to close</span>
+      </div>
+      <label for="command-palette-input" class="sr-only">Search commands</label>
+      <input
+        id="command-palette-input"
+        data-command-input
+        type="text"
+        autocomplete="off"
+        spellcheck="false"
+        class="mt-3 w-full rounded-sm border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 outline-none placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-background-light)] dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100 dark:placeholder:text-slate-400 dark:focus-visible:ring-offset-[var(--color-background-dark)]"
+        placeholder="Type a command..."
+      />
+      <p class="mt-2 text-xs font-display text-slate-500 dark:text-slate-400">Use Cmd/Ctrl+K or / to open</p>
+    </div>
+
+    <ul
+      data-command-results
+      class="max-h-80 overflow-y-auto p-2"
+      role="listbox"
+      aria-label="Available commands"
+    />
+  </div>
+</div>
+
+<script is:inline type="application/json" id="command-palette-actions" set:html={JSON.stringify(actions)} />
+
+<script>
+  const OPEN_EVENT = "command-palette:open";
+  const ROOT_SELECTOR = "[data-command-palette]";
+  const INPUT_SELECTOR = "[data-command-input]";
+  const RESULTS_SELECTOR = "[data-command-results]";
+
+  interface PaletteAction {
+    id: string;
+    label: string;
+    description: string;
+    href: string;
+    kind: string;
+    keywords: string;
+  }
+
+  function loadActions(): PaletteAction[] {
+    const el = document.getElementById("command-palette-actions");
+    if (!el?.textContent) return [];
+    try { return JSON.parse(el.textContent); } catch { return []; }
+  }
+
+  let allActions: PaletteAction[] = [];
+  let filteredActions: PaletteAction[] = [];
+  let activeIndex = 0;
+  let previousFocusedElement: HTMLElement | null = null;
+
+  function getNodes() {
+    const root = document.querySelector(ROOT_SELECTOR);
+    if (!(root instanceof HTMLElement)) return null;
+    const input = root.querySelector(INPUT_SELECTOR);
+    const results = root.querySelector(RESULTS_SELECTOR);
+    if (!(input instanceof HTMLInputElement) || !(results instanceof HTMLElement)) return null;
+    return { root, input, results };
+  }
+
+  function isPaletteOpen() {
+    const nodes = getNodes();
+    return nodes ? nodes.root.dataset.open === "true" : false;
+  }
+
+  function isEditableTarget(target: EventTarget | null) {
+    if (!(target instanceof HTMLElement)) return false;
+    const tagName = target.tagName;
+    return target.isContentEditable || tagName === "INPUT" || tagName === "TEXTAREA" || tagName === "SELECT";
+  }
+
+  function matchesAction(action: PaletteAction, query: string) {
+    if (!query) return true;
+    const normalized = query.toLowerCase().trim();
+    if (!normalized) return true;
+    return [action.label, action.description, action.keywords].join(" ").toLowerCase().includes(normalized);
+  }
+
+  function closePalette() {
+    const nodes = getNodes();
+    if (!nodes) return;
+    nodes.root.classList.add("hidden");
+    nodes.root.dataset.open = "false";
+    nodes.root.setAttribute("aria-hidden", "true");
+    if (previousFocusedElement instanceof HTMLElement) previousFocusedElement.focus();
+    previousFocusedElement = null;
+  }
+
+  function executeAction(action: PaletteAction) {
+    if (!action?.href) return;
+    closePalette();
+    if (action.kind === "external") { window.location.href = action.href; return; }
+    if (action.kind === "download") { window.open(action.href, "_blank", "noopener"); return; }
+    window.location.assign(action.href);
+  }
+
+  function renderResults() {
+    const nodes = getNodes();
+    if (!nodes) return;
+    nodes.results.textContent = "";
+
+    if (filteredActions.length === 0) {
+      const emptyState = document.createElement("li");
+      emptyState.className = "rounded-sm px-3 py-4 text-sm text-slate-500 dark:text-slate-400";
+      emptyState.textContent = "No commands found.";
+      nodes.results.appendChild(emptyState);
+      return;
+    }
+
+    filteredActions.forEach((action, index) => {
+      const item = document.createElement("li");
+      const button = document.createElement("button");
+      button.type = "button";
+      button.dataset.commandItem = "true";
+      button.dataset.commandIndex = String(index);
+      button.setAttribute("role", "option");
+      button.setAttribute("aria-selected", index === activeIndex ? "true" : "false");
+      button.className = [
+        "flex w-full items-start justify-between rounded-sm px-3 py-2 text-left transition-colors",
+        index === activeIndex
+          ? "bg-slate-100 text-slate-900 dark:bg-slate-800 dark:text-slate-100"
+          : "text-slate-800 hover:bg-slate-100 dark:text-slate-200 dark:hover:bg-slate-800",
+      ].join(" ");
+
+      const copy = document.createElement("span");
+      copy.className = "flex flex-col gap-0.5";
+      const label = document.createElement("span");
+      label.className = "text-sm font-medium";
+      label.textContent = action.label;
+      const description = document.createElement("span");
+      description.className = "text-xs text-slate-500 dark:text-slate-400";
+      description.textContent = action.description;
+      copy.appendChild(label);
+      copy.appendChild(description);
+
+      const hint = document.createElement("span");
+      hint.className = "ml-4 text-xs text-slate-500 dark:text-slate-400";
+      hint.textContent = action.kind === "download" ? "PDF" : action.kind === "external" ? "Mail" : "Open";
+
+      button.appendChild(copy);
+      button.appendChild(hint);
+      item.appendChild(button);
+      nodes.results.appendChild(item);
+    });
+  }
+
+  function openPalette() {
+    const nodes = getNodes();
+    if (!nodes) return;
+    previousFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    nodes.root.classList.remove("hidden");
+    nodes.root.dataset.open = "true";
+    nodes.root.setAttribute("aria-hidden", "false");
+    nodes.input.value = "";
+    filteredActions = [...allActions];
+    activeIndex = 0;
+    renderResults();
+    requestAnimationFrame(() => nodes.input.focus());
+  }
+
+  function moveSelection(offset: number) {
+    if (filteredActions.length === 0) return;
+    activeIndex = (activeIndex + offset + filteredActions.length) % filteredActions.length;
+    renderResults();
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    const target = event.target;
+    const shortcutPressed =
+      (event.key.toLowerCase() === "k" && (event.metaKey || event.ctrlKey)) ||
+      (event.key === "/" && !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey && !isEditableTarget(target));
+
+    if (!isPaletteOpen() && shortcutPressed) { event.preventDefault(); openPalette(); return; }
+    if (!isPaletteOpen()) return;
+    if (event.key === "Escape") { event.preventDefault(); closePalette(); return; }
+    if (event.key === "ArrowDown") { event.preventDefault(); moveSelection(1); return; }
+    if (event.key === "ArrowUp") { event.preventDefault(); moveSelection(-1); return; }
+    if (event.key === "Enter") {
+      const selectedAction = filteredActions[activeIndex];
+      if (!selectedAction) return;
+      event.preventDefault();
+      executeAction(selectedAction);
+    }
+  }
+
+  function handleInput(event: Event) {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement) || !target.matches(INPUT_SELECTOR)) return;
+    filteredActions = allActions.filter((a) => matchesAction(a, target.value));
+    activeIndex = 0;
+    renderResults();
+  }
+
+  function handleClick(event: MouseEvent) {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    if (target.closest("[data-command-backdrop]")) { closePalette(); return; }
+    const itemButton = target.closest("[data-command-item]");
+    if (!(itemButton instanceof HTMLElement)) return;
+    const action = filteredActions[Number(itemButton.dataset.commandIndex)];
+    if (action) executeAction(action);
+  }
+
+  // Listeners attach to document/window once and survive view transitions.
+  // `astro:page-load` re-runs after each navigation so per-page action data
+  // (latest project/post pulled at build time) is refreshed.
+  let bound = false;
+  document.addEventListener('astro:page-load', () => {
+    allActions = loadActions();
+    filteredActions = [...allActions];
+    activeIndex = 0;
+    renderResults();
+
+    if (bound) return;
+    bound = true;
+    document.addEventListener("keydown", handleKeydown);
+    document.addEventListener("input", handleInput);
+    document.addEventListener("click", handleClick);
+    window.addEventListener(OPEN_EVENT, openPalette);
+  });
+</script>

--- a/src/components/CommandPaletteHint.astro
+++ b/src/components/CommandPaletteHint.astro
@@ -1,0 +1,65 @@
+<button
+  type="button"
+  data-command-palette-hint
+  class="fixed bottom-4 left-4 z-40 inline-flex items-center gap-2 rounded-sm border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-display font-medium text-slate-700 shadow-sm hover:bg-white focus-ring dark:border-slate-800 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+  aria-label="Open command palette"
+  style="visibility:hidden"
+>
+  <span class="text-slate-500 dark:text-slate-400">Quick actions</span>
+  <span class="inline-flex items-center gap-1">
+    <kbd
+      data-command-modifier
+      class="inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-sm border border-slate-200 bg-white px-2 text-sm font-semibold leading-none text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200"
+      aria-hidden="true"
+    >
+      ⌃
+    </kbd>
+    <span
+      class="inline-flex h-6 items-center justify-center px-0.5 text-xs font-semibold text-slate-500 dark:text-slate-400"
+      aria-hidden="true"
+    >
+      +
+    </span>
+    <kbd
+      class="inline-flex h-6 min-w-[1.5rem] items-center justify-center rounded-sm border border-slate-200 bg-white px-2 text-sm font-semibold leading-none text-slate-700 dark:border-slate-700 dark:bg-slate-950 dark:text-slate-200"
+      aria-hidden="true"
+    >
+      K
+    </kbd>
+  </span>
+  <span data-command-shortcut-label class="sr-only">Ctrl + K</span>
+</button>
+
+<script>
+  const HINT_SELECTOR = "[data-command-palette-hint]";
+  const MODIFIER_SELECTOR = "[data-command-modifier]";
+  const LABEL_SELECTOR = "[data-command-shortcut-label]";
+  const OPEN_EVENT = "command-palette:open";
+
+  let cleanup: (() => void) | undefined;
+
+  function initCommandPaletteHint() {
+    cleanup?.();
+    const hint = document.querySelector(HINT_SELECTOR);
+    if (!(hint instanceof HTMLButtonElement)) return;
+
+    const modifier = hint.querySelector(MODIFIER_SELECTOR);
+    const label = hint.querySelector(LABEL_SELECTOR);
+    if (modifier instanceof HTMLElement) {
+      const userAgent = navigator.userAgent || "";
+      const isMac = /Mac|iPhone|iPad|iPod/i.test(userAgent);
+      modifier.textContent = isMac ? "⌘" : "⌃";
+      if (label instanceof HTMLElement) {
+        label.textContent = isMac ? "Command + K" : "Control + K";
+      }
+    }
+
+    hint.style.visibility = "visible";
+
+    const onClick = () => window.dispatchEvent(new CustomEvent(OPEN_EVENT));
+    hint.addEventListener("click", onClick);
+    cleanup = () => hint.removeEventListener("click", onClick);
+  }
+
+  document.addEventListener('astro:page-load', initCommandPaletteHint);
+</script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,8 @@ import SiteFooter from "../components/SiteFooter.astro";
 import TopoBackground from "../components/TopoBackground.tsx";
 import LoadingOverlay from "../components/LoadingOverlay.tsx";
 import BackToTop from "../components/BackToTop.astro";
+import CommandPalette from "../components/CommandPalette.astro";
+import CommandPaletteHint from "../components/CommandPaletteHint.astro";
 
 import {SITE} from '@/config';
 
@@ -98,6 +100,8 @@ const {
 <LoadingOverlay client:only="react" />
 <TopoBackground client:only="react" />
 <BackToTop />
+<CommandPalette />
+<CommandPaletteHint />
 <SiteHeader />
 
 <main id="main-content" class="relative z-10 max-w-7xl mx-auto px-6 py-12">


### PR DESCRIPTION
## Summary

Add a command palette component that provides quick access to key site sections, latest content, and contact actions. Users can open it with Cmd/Ctrl+K or "/" and search/navigate using keyboard or mouse.

## Changes

- **CommandPalette.astro**: New component that renders a modal dialog with searchable quick actions. Fetches latest project and blog post at build time. Includes keyboard navigation (arrow keys, enter), search filtering, and support for route, external, and download actions.
- **CommandPaletteHint.astro**: New component that displays a floating hint button in the bottom-left corner showing the keyboard shortcut (Cmd+K or Ctrl+K depending on OS). Dispatches event to open the palette.
- **Layout.astro**: Integrated both new components into the main layout so they're available site-wide.

## Testing

- [x] `npm run build` passes
- [x] Previewed locally with `npm run preview`
- [x] Keyboard shortcuts work (Cmd/Ctrl+K and "/" to open)
- [x] Search filtering works correctly
- [x] Navigation to routes, external links, and downloads function properly
- [x] Hint button displays correct modifier key (⌘ on Mac, ⌃ on other OS)

## Checklist

- [x] Type-check passes (`astro check`)
- [x] Docs updated if needed (CLAUDE.md, docs/)
- [x] Conventional commit message used

https://claude.ai/code/session_016eVjKUHNXqLUo3ocZ9St11